### PR TITLE
Fix embedding kmm run script phase

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -97,7 +97,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */;
 			buildPhases = (
-				7555FFB5242A651A00829871 /* ShellScript */,
+				7555FFB5242A651A00829871 /* Embed Shared KMM Code */,
 				7555FF77242A565900829871 /* Sources */,
 				7555FF78242A565900829871 /* Frameworks */,
 				7555FF79242A565900829871 /* Resources */,
@@ -158,7 +158,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		7555FFB5242A651A00829871 /* ShellScript */ = {
+		7555FFB5242A651A00829871 /* Embed Shared KMM Code */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -167,13 +167,14 @@
 			);
 			inputPaths = (
 			);
+			name = "Embed Shared KMM Code";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export JAVA_HOME=/opt/homebrew/opt/openjdk\ncd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
+			shellScript = "ANDROID_STUDIO_JDK_PATH=\"/Applications/Android Studio.app/Contents/jbr/Contents/Home\"\nif [ -d \"$ANDROID_STUDIO_JDK_PATH\" ]; then\n    export JAVA_HOME=\"$ANDROID_STUDIO_JDK_PATH\"\nelse\n    export JAVA_HOME=/opt/homebrew/opt/openjdk\nfi\ncd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
I updated the script that embeds KMM code into iOS:  

On those machines where Android Studio has its own jdk, point `JAVA_HOME` for `gradlew` Xcode to use jdk that comes with Android Studio.  
Otherwise, it will still be pointing to default `JAVA_HOME`.