### PR TITLE
[iOS] Add current round view and container variation

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		92E248D0299F716D00CF5147 /* NavPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E248CF299F716D00CF5147 /* NavPath.swift */; };
 		92F23CF729A4EE5F0093D043 /* LoadingModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F23CF629A4EE5F0093D043 /* LoadingModifier.swift */; };
 		92F23CF929A4EEA50093D043 /* ButtonLoadingModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F23CF829A4EEA50093D043 /* ButtonLoadingModifier.swift */; };
+		92F23CFB29A4F45E0093D043 /* CurrentRoundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F23CFA29A4F45E0093D043 /* CurrentRoundView.swift */; };
+		92F23CFD29A4F91B0093D043 /* HeaderSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F23CFC29A4F91B0093D043 /* HeaderSize.swift */; };
 		92F57CA4299551C4005D5328 /* LobbyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F57CA3299551C4005D5328 /* LobbyView.swift */; };
 /* End PBXBuildFile section */
 
@@ -130,6 +132,8 @@
 		92E248CF299F716D00CF5147 /* NavPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NavPath.swift; path = iosApp/Utility/NavPath.swift; sourceTree = SOURCE_ROOT; };
 		92F23CF629A4EE5F0093D043 /* LoadingModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingModifier.swift; sourceTree = "<group>"; };
 		92F23CF829A4EEA50093D043 /* ButtonLoadingModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonLoadingModifier.swift; sourceTree = "<group>"; };
+		92F23CFA29A4F45E0093D043 /* CurrentRoundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentRoundView.swift; sourceTree = "<group>"; };
+		92F23CFC29A4F91B0093D043 /* HeaderSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderSize.swift; sourceTree = "<group>"; };
 		92F57CA3299551C4005D5328 /* LobbyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LobbyView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -236,16 +240,17 @@
 			isa = PBXGroup;
 			children = (
 				92E9AC07299A358A000367F2 /* Buttons */,
+				92F23CFE29A4F93A0093D043 /* Header */,
 				92F23CF529A4E5800093D043 /* Loading */,
 				92E9AC08299A35C9000367F2 /* Lobby */,
 				7555FF82242A565900829871 /* ContentView.swift */,
+				92F23CFA29A4F45E0093D043 /* CurrentRoundView.swift */,
 				92A0603D299FD18800C6CC3E /* MenuEffectProcessor.swift */,
 				92A0603B299FCEE900C6CC3E /* LobbyEffectProcessor.swift */,
 				927F7F61298D1EB800A158A8 /* EnterScreenView.swift */,
 				921076652994E46900390F45 /* EnterScreenStage.swift */,
 				92CD661E2992DEA80003634C /* ContainerView.swift */,
 				92CD661C2992BD770003634C /* InputField.swift */,
-				92CD661A2992B83B0003634C /* HeaderView.swift */,
 				92A0603F29A24FB400C6CC3E /* AnswerCard.swift */,
 				927F7F5F298D075400A158A8 /* MainMenuView.swift */,
 			);
@@ -316,6 +321,15 @@
 				92F23CF829A4EEA50093D043 /* ButtonLoadingModifier.swift */,
 			);
 			path = Loading;
+			sourceTree = "<group>";
+		};
+		92F23CFE29A4F93A0093D043 /* Header */ = {
+			isa = PBXGroup;
+			children = (
+				92CD661A2992B83B0003634C /* HeaderView.swift */,
+				92F23CFC29A4F91B0093D043 /* HeaderSize.swift */,
+			);
+			path = Header;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -521,12 +535,14 @@
 				921076662994E46900390F45 /* EnterScreenStage.swift in Sources */,
 				927295EA298D7A6B00C5F0DE /* Assets.swift in Sources */,
 				92F23CF729A4EE5F0093D043 /* LoadingModifier.swift in Sources */,
+				92F23CFB29A4F45E0093D043 /* CurrentRoundView.swift in Sources */,
 				92E17D91299CEED300A0EEFC /* Fonts.swift in Sources */,
 				927295E3298D61F100C5F0DE /* PrimaryButton.swift in Sources */,
 				92DE7810299D7C1100B16131 /* Array+Extensions.swift in Sources */,
 				92A0603E299FD18800C6CC3E /* MenuEffectProcessor.swift in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
+				92F23CFD29A4F91B0093D043 /* HeaderSize.swift in Sources */,
 				92CD661D2992BD770003634C /* InputField.swift in Sources */,
 				92CD661B2992B83B0003634C /* HeaderView.swift in Sources */,
 				92F23CF929A4EEA50093D043 /* ButtonLoadingModifier.swift in Sources */,

--- a/iosApp/iosApp/UXHelpers/Fonts.swift
+++ b/iosApp/iosApp/UXHelpers/Fonts.swift
@@ -16,4 +16,5 @@ extension Font {
     static var bodyTertiary: Font { .custom("Unbounded-Medium", size: 12) }
     static var inputPrimary: Font { .custom("Unbounded-Medium", size: 16) }
     static var titleBoldSecondary: Font { .custom("Unbounded-Bold", size: 24) }
+    static var largeTitleSemiBold: Font { .custom("Unbounded-SemiBold", size: 32) }
 }

--- a/iosApp/iosApp/View/ContainerView.swift
+++ b/iosApp/iosApp/View/ContainerView.swift
@@ -9,9 +9,14 @@
 import SwiftUI
 
 struct ContainerView<Content: View>: View {
-    let content: Content
+    private let headerSize: HeaderSize
+    private let content: Content
 
-    init(@ViewBuilder _ content: () -> Content) {
+    init(
+        _ headerSize: HeaderSize = .medium,
+        @ViewBuilder _ content: () -> Content
+    ) {
+        self.headerSize = headerSize
         self.content = content()
     }
 
@@ -26,7 +31,7 @@ struct ContainerView<Content: View>: View {
             }
             .ignoresSafeArea(.all)
             VStack {
-                HeaderView()
+                HeaderView(size: headerSize)
                     .fixedSize(horizontal: false, vertical: true)
                     .ignoresSafeArea(.all)
                 content
@@ -41,8 +46,13 @@ struct ContainerView<Content: View>: View {
 
 struct ContainerView_Previews: PreviewProvider {
     static var previews: some View {
-        ContainerView {
-            Spacer()
+        Group {
+            ContainerView(.small) {
+                Spacer()
+            }
+            ContainerView(.medium) {
+                Spacer()
+            }
         }
     }
 }

--- a/iosApp/iosApp/View/ContainerView.swift
+++ b/iosApp/iosApp/View/ContainerView.swift
@@ -13,10 +13,10 @@ struct ContainerView<Content: View>: View {
     private let content: Content
 
     init(
-        _ headerSize: HeaderSize = .medium,
+        header: HeaderSize = .medium,
         @ViewBuilder _ content: () -> Content
     ) {
-        self.headerSize = headerSize
+        self.headerSize = header
         self.content = content()
     }
 
@@ -35,6 +35,8 @@ struct ContainerView<Content: View>: View {
                     .fixedSize(horizontal: false, vertical: true)
                     .ignoresSafeArea(.all)
                 content
+                Spacer()
+                    .frame(height: .extraLarge)
             }
             .ignoresSafeArea(.all, edges: .top)
         }
@@ -47,10 +49,10 @@ struct ContainerView<Content: View>: View {
 struct ContainerView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            ContainerView(.small) {
+            ContainerView(header: .small) {
                 Spacer()
             }
-            ContainerView(.medium) {
+            ContainerView(header: .medium) {
                 Spacer()
             }
         }

--- a/iosApp/iosApp/View/CurrentRoundView.swift
+++ b/iosApp/iosApp/View/CurrentRoundView.swift
@@ -14,7 +14,7 @@ struct CurrentRoundView: View {
     // MARK: - Body
 
     var body: some View {
-        ContainerView(.small) {
+        ContainerView(header: .small) {
             VStack {
                 Spacer()
                 Text("Раунд \(round)")

--- a/iosApp/iosApp/View/CurrentRoundView.swift
+++ b/iosApp/iosApp/View/CurrentRoundView.swift
@@ -1,0 +1,34 @@
+//
+//  CurrentRoundView.swift
+//  iosApp
+//
+//  Created by Artem Yelizarov on 21.02.2023.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import SwiftUI
+
+struct CurrentRoundView: View {
+    let round: Int
+
+    // MARK: - Body
+
+    var body: some View {
+        ContainerView(.small) {
+            VStack {
+                Spacer()
+                Text("Раунд \(round)")
+                    .font(.largeTitleSemiBold)
+                Spacer()
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+struct CurrentRoundView_Previews: PreviewProvider {
+    static var previews: some View {
+        CurrentRoundView(round: 1)
+    }
+}

--- a/iosApp/iosApp/View/EnterScreenView.swift
+++ b/iosApp/iosApp/View/EnterScreenView.swift
@@ -58,7 +58,6 @@ struct EnterScreenView: View {
                 }
                 .padding(.leading, 40)
                 .padding(.trailing, 36)
-                .padding(.bottom, .extraLarge)
             }
         }
         .onAppear {

--- a/iosApp/iosApp/View/Header/HeaderSize.swift
+++ b/iosApp/iosApp/View/Header/HeaderSize.swift
@@ -1,0 +1,35 @@
+//
+//  HeaderSize.swift
+//  iosApp
+//
+//  Created by Artem Yelizarov on 21.02.2023.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import Foundation
+
+enum HeaderSize {
+    case small
+    case medium
+
+    var height: CGFloat {
+        switch self {
+        case .small: return 146
+        case .medium: return 210
+        }
+    }
+
+    var logoWidth: CGFloat {
+        switch self {
+        case .small: return 180
+        case .medium: return 238
+        }
+    }
+
+    var headerBackgroundBottomPadding: CGFloat {
+        switch self {
+        case .small: return 18
+        case .medium: return 28
+        }
+    }
+}

--- a/iosApp/iosApp/View/Header/HeaderView.swift
+++ b/iosApp/iosApp/View/Header/HeaderView.swift
@@ -9,23 +9,24 @@
 import SwiftUI
 
 struct HeaderView: View {
+    let size: HeaderSize
 
     // MARK: - Body
 
     var body: some View {
         ZStack {
             Image.bgTexture
-                .padding(.bottom, 44)
+                .padding(.bottom, size.headerBackgroundBottomPadding)
             VStack {
                 Spacer()
                 Image.logo
                     .resizable()
                     .scaledToFit()
-                    .frame(width: 238)
+                    .frame(width: size.logoWidth)
             }
         }
         .ignoresSafeArea()
-        .frame(height: 210)
+        .frame(height: size.height)
     }
 }
 
@@ -34,7 +35,7 @@ struct HeaderView: View {
 struct HeaderView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            HeaderView()
+            HeaderView(size: .medium)
             Spacer()
         }
     }

--- a/iosApp/iosApp/View/Lobby/LobbyView.swift
+++ b/iosApp/iosApp/View/Lobby/LobbyView.swift
@@ -81,7 +81,6 @@ struct LobbyView: View {
             .padding(.top, .large)
             .padding(.leading, 40)
             .padding(.trailing, 36)
-            .padding(.bottom, .extraLarge)
             .ignoresSafeArea(.all)
         }
         .onAppear {


### PR DESCRIPTION
## In this PR:
- Implemented "current round" view
- Added `small` variation to `ContainerView`
- Fixed bottom padding in `ContainerView`, so there's no more need for adding bottom padding in every content
related to #17 
## Screenshot
[<img src="https://user-images.githubusercontent.com/105276702/220355793-5e50eb25-f0c0-4676-b0ae-dad79f4db20f.png" width=40%>](https://user-images.githubusercontent.com/105276702/220355793-5e50eb25-f0c0-4676-b0ae-dad79f4db20f.png)
